### PR TITLE
Send keystrokes to quit mame

### DIFF
--- a/pi-mame-manager.pl
+++ b/pi-mame-manager.pl
@@ -119,7 +119,12 @@ sub SecondsToHumanReadableTime
 sub ShutdownMame()
 {
   my $mame_pid = `pidof $MAME_EXE`;
-  kill( "SIGTERM", $mame_pid );
+  
+  # Fake the button pushes to exit so high scores are saved
+  system( "echo -ne \"\\t\" > /proc/$mame_pid/fd/0" );  # tab
+  system( "echo -ne $'\031' > /proc/$mame_pid/fd/0" );  # down arrow
+  system( "echo -ne \"\\n\" > /proc/$mame_pid/fd/0" );  # return
+  
   waitpid( $mame_pid, 0 );
 }
 


### PR DESCRIPTION
Instead of killing the process, send the keystrokes you'd push to exit. This should allow high scores to be saved.